### PR TITLE
Remove explicit argparse dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,5 @@ ase
 pathos
 jupyter
 scikit-learn
-argparse
 torch
 torch_geometric


### PR DESCRIPTION
As of [Python  >= 3.2](https://docs.python.org/3/library/argparse.html), the `argparse` module is maintained within the Python standard library and must not be installed from PyPI anymore.

This should slightly speed up the installation procedure